### PR TITLE
docs: clarify env parameter

### DIFF
--- a/OUTPUT_SYSTEM.md
+++ b/OUTPUT_SYSTEM.md
@@ -43,7 +43,7 @@ Unlike v1.x with its complex multiple strategies, v2.0 uses **one simple approac
 generate_outputs_for_modules(env, processed_modules...)
 # Purpose: Generate outputs for modules that were successfully processed
 # Parameters:
-#   $1 - Environment name (dev, dev, etc.)
+#   $1 - Environment name (dev, test, etc.)
 #   $2+ - List of modules that were processed by terragrunt
 # Returns: 0 on success, 1 on failure
 # Workflow: For each module → cd module → terragrunt output > outputs.json → copy to centralized


### PR DESCRIPTION
## Summary
- document the environment parameter of `generate_outputs_for_modules` as "Environment name (dev, test, etc.)"

## Testing
- `./tests/run_tests.sh --unit` *(fails: /workspace/infra/src/infra/shared.sh: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6890108b724c8333894951e8760975e5